### PR TITLE
Support PHPUnit namespaces (5.7+ optional, 6+ required)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^5.2"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "files": [

--- a/src/Expect.php
+++ b/src/Expect.php
@@ -2,7 +2,7 @@
 
 namespace Expect;
 
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert as Assert;
 
 class Expect
 {


### PR DESCRIPTION
PHPUnit 5.7 introduced a forwards compatible namespace approach for the `PHPUnit_Framework_Assert` class (aliased as `PHPUnit\Framework\Assert`).

This is the class name from PHPUnit 6.0+ to today's 8.1.2.